### PR TITLE
bugfix: expr like '0 * * * * * *' can not work properly

### DIFF
--- a/crython/crython.py
+++ b/crython/crython.py
@@ -101,7 +101,7 @@ class CronExpression(object):
     def __init__(self, **kwargs):
         expression = kwargs.get('expr')
         if expression.startswith('@'):
-            expression = self.KEYWORDS.get(expr, '* * * * * * *')
+            expression = self.KEYWORDS.get(expression, '* * * * * * *')
         
         expression = dict(zip(self.FIELD_NAMES, expression.split()))
         for field, ctor in self.FIELDS.items():

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,14 +3,14 @@
 from crython import crython
 import time
 
-# @crython.job(expr='@minitely')
+# @crython.job(expr='@minutely')
 @crython.job(expr='0 * * * * * *')
 def task1():
     print 'task1 will be called every minitus'
 
 @crython.job(expr='0 0 * * *')
 def task2():
-    print 'will be called every hour'
+    print 'task2 will be called every hour'
 
 crython.tab.start()
 


### PR DESCRIPTION
bugfixed: No matter what the expression is (such as "0 \* \* \* \* \* *", "0 0 \* \* \* \* *"), the task will be called every second, instead of every minute "0 \* \* \* \* \* *" and every hour "0 0 \* \* \* \* *".
