### PR TITLE
Don't pass args/kwargs to thread init.

### DIFF
--- a/crython/tab.py
+++ b/crython/tab.py
@@ -33,7 +33,7 @@ class CronTab(threading.Thread):
     """
 
     def __init__(self, *args, **kwargs):
-        super(CronTab, self).__init__(*args, **kwargs)
+        super(CronTab, self).__init__()
         self.name = 'CronTab ({0})'.format(kwargs.get('name', id(self)))
         self.daemon = True
         self.jobs = {}


### PR DESCRIPTION
There's no reason to do this as we override the thread
run function.

Fixes #23