### PR TITLE
Fix int/str type comparisons for py27/py3.

### DIFF
--- a/crython/compat.py
+++ b/crython/compat.py
@@ -38,5 +38,8 @@ range = six.moves.range
 str = str if six.PY3 else unicode
 zip = six.moves.zip
 
+int_types = six.integer_types
+str_types = six.string_types
+
 
 __all__ = []

--- a/crython/field.py
+++ b/crython/field.py
@@ -135,7 +135,7 @@ def _check_and_parse_if_number(value):
     :return: A two item tuple containing a boolean indicating the conversion success and the converted value.
     """
     value = _int_try_parse(value)
-    return isinstance(value, compat.int), value
+    return isinstance(value, compat.int_types), value
 
 
 def _invalid_special_chars(value, valid_specials, all_specials=ALL_SPECIALS):
@@ -166,9 +166,9 @@ class CronField(compat.object):
         :param kwargs: Additional keyword args
         :return: A :class:`~crython.field.CronField`
         """
-        if isinstance(value, compat.int):
+        if isinstance(value, compat.int_types):
             return cls.from_number(value, name, *args, **kwargs)
-        if isinstance(value, compat.str):
+        if isinstance(value, compat.str_types):
             return cls.from_str(value, name, *args, **kwargs)
         if isinstance(value, collections.Iterable):
             return cls.from_iterable(value, name, *args, **kwargs)
@@ -266,12 +266,12 @@ class CronField(compat.object):
         ..todo:: Recomputing this isn't very efficient. Consider converting the field or expression to a `datetime`
         or `timedelta` instance.
         """
-        if not isinstance(item, compat.int):
+        if not isinstance(item, compat.int_types):
             raise ValueError('Expected comparison with item of type int; got {0}'.format(type(item)))
 
-        if isinstance(self.value, compat.int):
+        if isinstance(self.value, compat.int_types):
             return self._matches_number(item)
-        if isinstance(self.value, compat.str):
+        if isinstance(self.value, compat.str_types):
             return self._matches_str(item)
         if isinstance(self.value, collections.Iterable):
             return self._matches_iterable(item)


### PR DESCRIPTION
The would break string based range matchers as it was not correctly
identifying it as a string field and converted it to an interable
that would never match.

**Sample Code:**
```
import crython
import time

@crython.job(second='*/3')
def foo_one_sec():
    print('{} - Fires every three seconds'.format(time.time()))

crython.start()
time.sleep(30)
crython.stop()
```

**Sample Output**
```
~/.pyenv/versions/2.7.12/bin/python ~/src/github.com/ahawker/crython/test.py
1491539631.45 - Fires every three seconds
1491539634.47 - Fires every three seconds
1491539637.48 - Fires every three seconds
1491539640.49 - Fires every three seconds
1491539643.51 - Fires every three seconds
1491539646.52 - Fires every three seconds
```