### PR TITLE
Fix inconsistency between Cron & struct_time for what day is zero.

### DIFF
--- a/crython/expression.py
+++ b/crython/expression.py
@@ -204,6 +204,7 @@ class CronExpression(compat.object):
         # field name -> :class:`~crython.field.CronField` on this expression instance that is used to
         # evaluate if the specific datetime value is a match.
         datetime_fields = dict(zip(STRUCT_TIME_FIELDS, dt.timetuple()[:FIELD_COUNT]))
+        datetime_fields[field.WEEKDAY_NAME] = (datetime_fields[field.WEEKDAY_NAME] + 1) % 7
         expression_fields = dict((name, self.__dict__[name]) for name in field.NAMES)
 
         return all(fields_lazy_eval(datetime_fields, expression_fields))

--- a/crython/field.py
+++ b/crython/field.py
@@ -408,7 +408,7 @@ month = functools.partial(CronField.new, name='month', min=1, max=12,
                                               RANGE_STEP_DELIMITER, VALUE_DELIMITER]))
 
 #: Partial for creating a :class:`~crython.CronField` that represents the "day of week".
-weekday = functools.partial(CronField.new, name='weekday', min=0, max=6,
+weekday = functools.partial(CronField.new, name='weekday', min=0, max=7,
                             specials=frozenset([ALL, RANGE_DELIMITER,
                                                 RANGE_STEP_DELIMITER, VALUE_DELIMITER,
                                                 NON_SPECIFIC, LAST, NTH]))

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -32,7 +32,6 @@ def reserved_keywords(request):
     dict(month=0),
     dict(month=13),
     dict(weekday=-1),
-    dict(weekday=7),  # TODO - #9
     dict(weekday=8),
     dict(year=0),
     dict(year=1969),


### PR DESCRIPTION
The cron syntax specifies the following:

* 0-6 (Sunday -> Saturday)
* 1-7 (Monday -> Sunday)

The struct_time sequence follows:

* 0-6 (Monday -> Sunday)

Fixes #9.