### PR TITLE
Fix 'README.md' to include correct examples on how to use the 'ctx' p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,20 @@ Call a function using [predefined keywords](https://github.com/ahawker/crython#k
         print "I call the big one bitey. - Homer Simpson"
 ```
 
+Call a function and run it within a separate thread (default behaviour if `ctx` is not specified):
+```python
+    # Fire once a week.
+    @crython.job(expr='@weekly', ctx='thread')
+    def foo():
+        print "No, no, dig up stupid. - Chief Wiggum"
+```
+
 Call a function and run it within a separate process:
 ```python
     # Fire every hour.
-    @crython.job(expr='@hourly', ctx='process')
+    @crython.job(expr='@hourly', ctx='multiprocess')
     def foo():
-        print "No, no, dig up stupid. - Chief Wiggum"
+        print "Eat my shorts. - Bart Simpson"
 ```
 
 Start the global job scheduler:  


### PR DESCRIPTION
…arameter

The 'ctx' parameter accepts one of two values: 'thread' to run the scheduled job on a separate thread, which is the default behaviour if no 'ctx' value is specified, or 'multiprocess' to run the scheduled job on a separate process. The 'README.md' file incorrectly showed 'process' as a valid value for the 'ctx' parameter and none of the correct values mentioned before.

Fixes: #254