### PR TITLE
Remove old py26 compatibility logging

### DIFF
--- a/crython/log.py
+++ b/crython/log.py
@@ -7,17 +7,11 @@
 # pylint: disable=global-statement
 import logging
 
-ROOT_LOGGER = None
+ROOT_LOGGER = logging.getLogger(__package__)
 
 
 def get_logger(name=None):
     """
     Get a logger instance relative to the crython package.
     """
-    global ROOT_LOGGER
-
-    if ROOT_LOGGER is None:
-        ROOT_LOGGER = logging.getLogger()
-
-    name = '.'.join((ROOT_LOGGER.name, name)) if name else None
-    return logging.getLogger(name)
+    return ROOT_LOGGER.getChild(name)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,22 @@
+"""
+    test_log
+    ~~~~~~~~
+
+    Tests for the :mod:`~crython.log` module.
+"""
+from crython import log
+
+
+def test_root_logger_uses_package_name():
+    """
+    Assert that the root logger uses the package name.
+    """
+    assert log.ROOT_LOGGER.name == 'crython'
+
+
+def test_child_logger_name_path_starts_with_package_name():
+    """
+    Assert that child logs use the package name as the root value of the name path.
+    """
+    child = log.get_logger('foo')
+    assert child.name == 'crython.foo'


### PR DESCRIPTION
This code was creating loggers in py26+ versions that had the name
'root.crython...' instead of just 'crython.'. Since py26 is no longer
supported, it should be safe to remove this code. It's a backwards
compatbility breaking change however, for anyone that had figured
that out and used 'root.' in their logging configs.

If merged, this should fix #275 