### PR TITLE
Freeze pylint/pytest requirements for py34

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,8 @@
 
 bumpversion==0.5.3
 pylint==1.7.5; python_version < '2.7' or (python_version > '3.0' and python_version < '3.4')  # pyup: ignore
-pylint==2.4.2; (python_version > '2.7' and python_version < '3.0') or python_version >= '3.4'
+pylint==2.3.1; python_version == '3.4'  # pyup: ignore
+pylint==2.4.2; (python_version > '2.7' and python_version < '3.0') or python_version >= '3.5'
 safety==1.8.5
 bandit==1.6.2
 isort==4.2.15; python_version < '2.7' or (python_version > '3.0' and python_version < '3.4')  # pyup: ignore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,8 @@
 coverage==4.5.4
 
 pytest<3.3.0; python_version < '2.7' or (python_version > '3.0' and python_version < '3.4')  # pyup: ignore
-pytest==5.2.0; (python_version > '2.7' and python_version < '3.0') or python_version >= '3.4'
+pytest==4.6.5; python_version == '3.4'  # pyup: ignore
+pytest==5.2.0; (python_version > '2.7' and python_version < '3.0') or python_version >= '3.5'
 pytest-cov==2.7.1
 pytest-mock==1.6.3; python_version < '2.7' or (python_version > '3.0' and python_version < '3.4')  # pyup: ignore
 pytest-mock==1.11.0; (python_version > '2.7' and python_version < '3.0') or python_version >= '3.4'


### PR DESCRIPTION
This should fix broken Travis builds that are failing to find pylint 2.4.2 for py3.4.

Example: https://travis-ci.org/ahawker/crython/jobs/592254249

<blockquote><div><strong><a href="https://travis-ci.org/ahawker/crython/jobs/592254249">Travis CI - Test and Deploy Your Code with Confidence</a></strong></div></blockquote>