### PR TITLE
Fix broken py35 appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,9 @@ install:
   - "set MSSDK=1"
   - "set DISTUTILS_USE_SDK=1"
   - "python -m pip install --upgrade pip wheel setuptools"
-  - "make tox-install"
+  - "make test-install"
 test_script:
-  - "make tox"
+  - "set PYTHONPATH=."
+  - "make test"
 on_success:
   - "codecov -f coverage.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\MinGW\\bin;%PATH%"
   - "set MSSDK=1"
   - "set DISTUTILS_USE_SDK=1"
-  - "python -m pip install --upgrade pip wheel"
+  - "python -m pip install --upgrade pip wheel setuptools"
   - "make tox-install"
 test_script:
   - "make tox"


### PR DESCRIPTION
Trying to fix broken installation in py34 and py35 builds in Appveyor.

```
Exception:
Traceback (most recent call last):
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2851, in _dep_map
    return self.__dep_map
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2685, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\basecommand.py", line 209, in main
    status = self.run(options, args)
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\commands\install.py", line 310, in run
    wb.build(autobuilding=True)
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\wheel.py", line 748, in build
    self.requirement_set.prepare_files(self.finder)
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\req\req_set.py", line 360, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\req\req_set.py", line 647, in _prepare_file
    set(req_to_install.extras) - set(dist.extras)
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2810, in extras
    return [dep for dep in self._dep_map if dep]
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2853, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2886, in _compute_dependencies
    common = frozenset(reqs_for_extra(None))
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2883, in reqs_for_extra
    if req.marker_fn(override={'extra':extra}):
  File "c:\projects\crython\.tox\py35\lib\site-packages\pip\_vendor\_markerlib\markers.py", line 113, in marker_fn
    return eval(compiled_marker, environment)
  File "<environment marker>", line 1, in <module>
NameError: name 'platform_system' is not defined
Makefile:13: recipe for target 'test-install' failed
make.EXE: *** [test-install] Error 2

```